### PR TITLE
fix(headPoseEstimation): Rename attribute name according to changes in mediapipe library.

### DIFF
--- a/headPoseEstimation.py
+++ b/headPoseEstimation.py
@@ -123,7 +123,7 @@ while cap.isOpened():
         mp_drawing.draw_landmarks(
                     image=image,
                     landmark_list=face_landmarks,
-                    connections=mp_face_mesh.FACE_CONNECTIONS,
+                    connections=mp_face_mesh.FACEMESH_TESSELATION,
                     landmark_drawing_spec=drawing_spec,
                     connection_drawing_spec=drawing_spec)
 


### PR DESCRIPTION
Mediapipe library has renamed attribute name, causing following error:

```cmd
AttributeError: module 'mediapipe.python.solutions.face_mesh' has no attribute 'FACE_CONNECTIONS'
```

Resource: https://github.com/google/mediapipe/blob/master/mediapipe/python/solutions/holistic.py